### PR TITLE
Adiciona campos creators e contributors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY dist/* /tmp/pypa/
 
 RUN apt-get update && apt-get install python-lxml
 
+RUN pip install --upgrade pip
+
 RUN pip --no-cache-dir install -r /app/requirements.txt && \
     pip --no-cache-dir install -f file:///tmp/pypa -U booksoai
 

--- a/booksoai/pipeline.py
+++ b/booksoai/pipeline.py
@@ -219,12 +219,6 @@ class MetadataPipe(plumber.Pipe):
         title = etree.SubElement(oai_rec, '{%s}title' % self.dc)
         title.text = data.get('title')
 
-        creator = etree.SubElement(oai_rec, '{%s}creator' % self.dc)
-        try:
-            creator.text = data.get('creators').get('organizer')[0][0]
-        except TypeError:
-            oai_rec.remove(creator)
-            logger.info("Can't get organizer for id %s" % data.get('identifier'))
 
         contributor = etree.SubElement(oai_rec, '{%s}contributor' % self.dc)
         try:

--- a/booksoai/pipeline.py
+++ b/booksoai/pipeline.py
@@ -203,6 +203,10 @@ class MetadataPipe(plumber.Pipe):
     schemaLocation += " http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
     attrib = {"{%s}schemaLocation" % xsi: schemaLocation}
 
+    def _append_node(self, root, node_name, node_text):
+        node = etree.SubElement(root, node_name)
+        node.text = node_text
+
     @precondition(deleted_precond)
     def transform(self, item):
         xml, data = item

--- a/booksoai/pipeline.py
+++ b/booksoai/pipeline.py
@@ -222,6 +222,10 @@ class MetadataPipe(plumber.Pipe):
         for author_role in ['individual_author', 'corporate_author', 'organizer', 'coordinator']:
             for ar in data.get('creators', {}).get(author_role, []):
                 self._append_node(oai_rec, '{%s}creator' % self.dc, ar[0])
+            
+        for contributor_role in ['editor', 'collaborator', 'translator']:
+            for cr in data.get('creators', {}).get(contributor_role, []):
+                self._append_node(oai_rec, '{%s}contributor' % self.dc, cr[0])
 
         description = etree.SubElement(oai_rec, '{%s}description' % self.dc)
         description.text = data.get('description')

--- a/booksoai/pipeline.py
+++ b/booksoai/pipeline.py
@@ -219,6 +219,9 @@ class MetadataPipe(plumber.Pipe):
         title = etree.SubElement(oai_rec, '{%s}title' % self.dc)
         title.text = data.get('title')
 
+        for author_role in ['individual_author', 'corporate_author', 'organizer', 'coordinator']:
+            for ar in data.get('creators', {}).get(author_role, []):
+                self._append_node(oai_rec, '{%s}creator' % self.dc, ar[0])
 
         description = etree.SubElement(oai_rec, '{%s}description' % self.dc)
         description.text = data.get('description')

--- a/booksoai/pipeline.py
+++ b/booksoai/pipeline.py
@@ -220,13 +220,6 @@ class MetadataPipe(plumber.Pipe):
         title.text = data.get('title')
 
 
-        contributor = etree.SubElement(oai_rec, '{%s}contributor' % self.dc)
-        try:
-            contributor.text = data.get('creators').get('collaborator')[0][0]
-        except TypeError:
-            oai_rec.remove(contributor)
-            logger.info("Can't get collaborator for id %s" % data.get('identifier'))
-
         description = etree.SubElement(oai_rec, '{%s}description' % self.dc)
         description.text = data.get('description')
 

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -400,6 +400,52 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_organizer(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'organizer': [
+                    ['organizer1', None], 
+                    ['organizer2', None], 
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:creator>organizer1</dc:creator>'
+        xml_str += '<dc:creator>organizer2</dc:creator>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -550,6 +550,49 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_editor_contributor(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'editor': [
+                    ['editor1', None], 
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:contributor>editor1</dc:contributor>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -446,6 +446,65 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_multiple_author_groups(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'individual_author': [
+                    ['individual_author1', None], 
+                    ['individual_author2', None]
+                ],
+                'corporate_author': [
+                    ['corporate_author1', None], 
+                    ['corporate_author2', None], 
+                    ['corporate_author3', None]
+                ],
+                'organizer': [
+                    ['organizer1', None], 
+                    ['organizer2', None], 
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:creator>individual_author1</dc:creator>'
+        xml_str += '<dc:creator>individual_author2</dc:creator>'
+        xml_str += '<dc:creator>corporate_author1</dc:creator>'
+        xml_str += '<dc:creator>corporate_author2</dc:creator>'
+        xml_str += '<dc:creator>corporate_author3</dc:creator>'
+        xml_str += '<dc:creator>organizer1</dc:creator>'
+        xml_str += '<dc:creator>organizer2</dc:creator>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -505,6 +505,51 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_translator_contributor(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'translator': [
+                    ['translator1', None], 
+                    ['translator2', None]
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:contributor>translator1</dc:contributor>'
+        xml_str += '<dc:contributor>translator2</dc:contributor>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -309,6 +309,50 @@ class TestMetadataPipe(unittest.TestCase):
 
         self.assertEqual(etree.tostring(xml), xml_str)
 
+    def test_metadata_pipe_add_record_as_dublin_core_with_individual_author(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'individual_author': [
+                    ['individual_author1', None], 
+                    ['individual_author2', None]
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:creator>individual_author1</dc:creator>'
+        xml_str += '<dc:creator>individual_author2</dc:creator>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 
 class TestRecordPipe(unittest.TestCase):
 

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -692,6 +692,87 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_multiple_contributor_and_creator_groups(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'individual_author': [
+                    ['individual_author1', None], 
+                    ['individual_author2', None]
+                ],
+                'corporate_author': [
+                    ['corporate_author1', None], 
+                    ['corporate_author2', None], 
+                    ['corporate_author3', None]
+                ],
+                'organizer': [
+                    ['organizer1', None], 
+                    ['organizer2', None], 
+                ],
+                'translator': [
+                    ['translator1', None], 
+                    ['translator2', None]
+                ],
+                'editor': [
+                    ['editor1', None], 
+                    ['editor2', None], 
+                    ['editor3', None]
+                ],
+                'coordinator': [
+                    ['coordinator1', None], 
+                    ['coordinator2', None], 
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:creator>individual_author1</dc:creator>'
+        xml_str += '<dc:creator>individual_author2</dc:creator>'
+        xml_str += '<dc:creator>corporate_author1</dc:creator>'
+        xml_str += '<dc:creator>corporate_author2</dc:creator>'
+        xml_str += '<dc:creator>corporate_author3</dc:creator>'
+        xml_str += '<dc:creator>organizer1</dc:creator>'
+        xml_str += '<dc:creator>organizer2</dc:creator>'
+        xml_str += '<dc:creator>coordinator1</dc:creator>'
+        xml_str += '<dc:creator>coordinator2</dc:creator>'
+        xml_str += '<dc:contributor>editor1</dc:contributor>'
+        xml_str += '<dc:contributor>editor2</dc:contributor>'
+        xml_str += '<dc:contributor>editor3</dc:contributor>'
+        xml_str += '<dc:contributor>translator1</dc:contributor>'
+        xml_str += '<dc:contributor>translator2</dc:contributor>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
+
+
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -593,6 +593,52 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_coordinator_creator(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'coordinator': [
+                    ['coordinator1', None], 
+                    ['coordinator2', None], 
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:creator>coordinator1</dc:creator>'
+        xml_str += '<dc:creator>coordinator2</dc:creator>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -639,6 +639,59 @@ class TestMetadataPipe(unittest.TestCase):
         xml_str += '</root>'
 
         self.assertEqual(etree.tostring(xml), xml_str)
+
+    def test_metadata_pipe_add_record_as_dublin_core_with_multiple_contributor_groups(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'translator': [
+                    ['translator1', None], 
+                    ['translator2', None]
+                ],
+                'editor': [
+                    ['editor1', None], 
+                    ['editor2', None], 
+                    ['editor3', None]
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:contributor>editor1</dc:contributor>'
+        xml_str += '<dc:contributor>editor2</dc:contributor>'
+        xml_str += '<dc:contributor>editor3</dc:contributor>'
+        xml_str += '<dc:contributor>translator1</dc:contributor>'
+        xml_str += '<dc:contributor>translator2</dc:contributor>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/booksoai/tests/test_pipeline.py
+++ b/booksoai/tests/test_pipeline.py
@@ -354,6 +354,52 @@ class TestMetadataPipe(unittest.TestCase):
 
         self.assertEqual(etree.tostring(xml), xml_str)
 
+    def test_metadata_pipe_add_record_as_dublin_core_with_corporate_author(self):
+        data = {
+            'title': 'title',
+            'creators': {
+                'corporate_author': [
+                    ['corporate_author1', None], 
+                    ['corporate_author2', None], 
+                    ['corporate_author3', None]
+                ],
+            },
+            'description': 'description',
+            'publisher': 'publisher',
+            'date': '2014',
+            'formats': ['pdf', 'epub'],
+            'identifier': 'identifier',
+            'language': 'pt'
+        }
+        root = etree.Element('root')
+
+        pipe = pipeline.MetadataPipe()
+        xml, data = pipe.transform((root, data))
+
+        xml_str = '<root>'
+        xml_str += '<metadata>'
+        xml_str += '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"'
+        xml_str += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        xml_str += ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        xml_str += ' xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/'
+        xml_str += ' http://www.openarchives.org/OAI/2.0/oai_dc.xsd">'
+        xml_str += '<dc:title>title</dc:title>'
+        xml_str += '<dc:creator>corporate_author1</dc:creator>'
+        xml_str += '<dc:creator>corporate_author2</dc:creator>'
+        xml_str += '<dc:creator>corporate_author3</dc:creator>'
+        xml_str += '<dc:description>description</dc:description>'
+        xml_str += '<dc:publisher>publisher</dc:publisher>'
+        xml_str += '<dc:date>2014</dc:date>'
+        xml_str += '<dc:type>book</dc:type>'
+        xml_str += '<dc:format>pdf</dc:format>'
+        xml_str += '<dc:format>epub</dc:format>'
+        xml_str += '<dc:identifier>http://books.scielo.org/id/identifier</dc:identifier>'
+        xml_str += '<dc:language>pt</dc:language>'
+        xml_str += '</oai_dc:dc>'
+        xml_str += '</metadata>'
+        xml_str += '</root>'
+
+        self.assertEqual(etree.tostring(xml), xml_str)
 class TestRecordPipe(unittest.TestCase):
 
     def test_record_pipe_add_record_node(self):

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+    mongo:
+        image: mongo:latest
+        ports:
+          - "27017:27017"
+    webapp:
+        build: .
+        depends_on:
+          - mongo
+        links:
+          - mongo:mongo
+        ports:
+          - "6543:6543"
+        environment:
+          BOOKSOAI_MONGO_URI: 'mongodb://mongo:27017/scielobooks_oai'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requires = [
     ]
 
 setup(name='booksoai',
-      version='0.0',
+      version='0.1',
       description='booksoai',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
Altera a forma como o campo `creator` é construído de modo a permitir que:
- Existam vários elementos `<creator>`
- Existam vários elementos `<contributor>`

Em creator estão:
- individual_author
- corporate_author
- organizer
- coodinator

Em contributor estão:
- editor
- collaborator
- translator

Este PR também implementa os testes relacionados a esses campos, a saber:
- test_metadata_pipe_add_record_as_dublin_core_with_individual_author
- test_metadata_pipe_add_record_as_dublin_core_with_corporate_author
- test_metadata_pipe_add_record_as_dublin_core_with_organizer
- test_metadata_pipe_add_record_as_dublin_core_with_multiple_author_groups
- test_metadata_pipe_add_record_as_dublin_core_with_translator_contributor
- test_metadata_pipe_add_record_as_dublin_core_with_editor_contributor
- test_metadata_pipe_add_record_as_dublin_core_with_coordinator_creator
- test_metadata_pipe_add_record_as_dublin_core_with_multiple_contributor_groups
- test_metadata_pipe_add_record_as_dublin_core_with_multiple_contributor_and_creator_groups

Para rodar esses testes basta fazer: `python -m unittest booksoai.tests.test_pipeline.TestMetadataPipe`. Sugere-se fazer deste modo porque há muitos testes relacionados a implementações anteriores que estão com problema.