### PR TITLE
Remove wildcard de instrução Dockerfile para compatibilizar com buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV IMAGE_VCS_REF ${VCS_REF}
 ENV IMAGE_WEBAPP_VERSION ${WEBAPP_VERSION}
 
 COPY requirements.txt production.ini /app/
-COPY dist/* /tmp/pypa/
+COPY dist /tmp/pypa/
 
 RUN apt-get update && apt-get install python-lxml
 


### PR DESCRIPTION
Este PR faz uma pequena correção para tentar acertar o build que ocorre no Docker Hub, conforme https://github.com/docker/build-push-action/issues/517